### PR TITLE
Added note timestamp and clientside note queue

### DIFF
--- a/lua/entities/gmt_instrument_base/cl_init.lua
+++ b/lua/entities/gmt_instrument_base/cl_init.lua
@@ -60,11 +60,32 @@ ENT.BrowserHUD = {
 	Height = 768,
 }
 
+ENT.QueuedNotes = {}
+
 function ENT:Initialize()
 	self:PrecacheMaterials()
 end
 
 function ENT:Think()
+
+	local time = os.clock()
+
+	for k,v in pairs(self.QueuedNotes) do
+
+		if time>=v.timestamp then
+
+			self:EmitSound( v.sound, 90 )
+
+			// Note effect
+			local eff = EffectData()
+			eff:SetOrigin(v.pos)
+			util.Effect( "musicnotes", eff, true, true )
+
+			table.remove(self.QueuedNotes, k)
+
+		end
+
+	end
 
 	if !IsValid( LocalPlayer().Instrument ) || LocalPlayer().Instrument != self then return end
 
@@ -131,23 +152,23 @@ function ENT:OnRegisteredKeyPlayed( key )
 	local sound = self:GetSound( key )
 	self:EmitSound( sound, 100 )
 
+	//Note effect
+	local pos = string.sub( key, 2, 3 )
+	pos = math.Fit( tonumber( pos ), 1, 36, -3.8, 4 )
+	pos = LocalPlayer():GetPos() + Vector( -15, pos * 10, -5 ) 
+	local eff = EffectData()
+	eff:SetOrigin(pos)
+	util.Effect( "musicnotes", eff, true, true )
+
 	// Network it
 	net.Start( "InstrumentNetwork" )
 
 		net.WriteEntity( self )
 		net.WriteInt( INSTNET_PLAY, 3 )
 		net.WriteString( key )
+		net.WriteFloat(os.clock())
 
 	net.SendToServer()
-
-	// Add the notes (limit to max notes)
-	/*if #self.KeysToSend < self.MaxKeys then
-
-		if !table.HasValue( self.KeysToSend, key ) then // only different notes, please
-			table.insert( self.KeysToSend, key )
-		end
-
-	end*/
 
 end
 
@@ -275,7 +296,7 @@ function ENT:DrawHUD()
 
 end
 
-// This is so I don't have to do GetTextureID in the table EACH TIME, ugh
+// This is so I do not have to do GetTextureID in the table EACH TIME, ugh
 function ENT:PrecacheMaterials()
 
 	if !self.Keys then return end
@@ -321,7 +342,7 @@ function ENT:OpenSheetMusic()
 
 	self.Browser:OpenURL( url )
 
-	// This is delayed because otherwise it won't load at all
+	// This is delayed because otherwise it will not load at all
 	// for some silly reason...
 	timer.Simple( .1, function()
 
@@ -415,20 +436,16 @@ hook.Add( "HUDPaint", "InstrumentPaint", function()
 
 		// HUD
 		local inst = LocalPlayer().Instrument
-		if inst.DrawHUD then
-			inst:DrawHUD()
-		end
+		inst:DrawHUD()
 
 		// Notice bar
-		if inst.PrintName then
-			local name = inst.PrintName or "INSTRUMENT"
-			name = string.upper( name )
+		local name = inst.PrintName or "INSTRUMENT"
+		name = string.upper( name )
 
-			surface.SetDrawColor( 0, 0, 0, 180 )
-			surface.DrawRect( 0, ScrH() - 60, ScrW(), 60 )
+		surface.SetDrawColor( 0, 0, 0, 180 )
+		surface.DrawRect( 0, ScrH() - 60, ScrW(), 60 )
 
-			draw.SimpleText( "PRESS TAB TO LEAVE THE " .. name, "InstrumentNotice", ScrW() / 2, ScrH() - 35, Color(255, 255, 255), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 1 )
-		end
+		draw.SimpleText( "PRESS TAB TO LEAVE THE " .. name, "InstrumentNotice", ScrW() / 2, ScrH() - 35, Color(255, 255, 255), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 1 )
 
 	end
 
@@ -437,7 +454,7 @@ end )
 // Override regular keys
 hook.Add( "PlayerBindPress", "InstrumentHook", function( ply, bind, pressed )
 
-	if IsValid( ply ) && IsValid( ply.Instrument ) then
+	if IsValid( ply.Instrument ) then
 		return true
 	end
 
@@ -455,49 +472,39 @@ net.Receive( "InstrumentNetwork", function( length, client )
 			LocalPlayer().Instrument:Shutdown()
 		end
 
-		ent.DelayKey = CurTime() + .1 // delay to the key a bit so they don't play on use key
+		ent.DelayKey = CurTime() + .1 // delay to the key a bit so they do not play on use key
 		LocalPlayer().Instrument = ent
 
 	// Play the notes for everyone else
 	elseif enum == INSTNET_HEAR then
 
-		// Instrument doesn't exist
+		// Instrument does not exist
 		if !IsValid( ent ) then return end
-
-		// Don't play for the owner, they've already heard it!
-		if IsValid( LocalPlayer().Instrument ) && LocalPlayer().Instrument == ent then
-			return
-		end
-
-		if !ent.GetSound then return end
 
 		// Gather note
 		local key = net.ReadString()
 		local sound = ent:GetSound( key )
-			
-		if sound then
-			ent:EmitSound( sound, 80 )
+		local timestamp = net.ReadFloat()
+		local pos = net.ReadVector()
+
+		// Do not play for the owner
+		if IsValid( LocalPlayer().Instrument ) && LocalPlayer().Instrument == ent then
+			return
 		end
 
-		// Gather notes
-		/*local keys = net.ReadTable()
-	
-		for i=1, #keys do
+		// Calculate timing offset - how much farther ahead the server clock is to ours
+		if not inst_timing_offset then
+			inst_timing_offset = timestamp - os.clock()
+		end
 
-			local key = keys[1]
-			local sound = ent:GetSound( key )
+		//Calculate true time when sound should play
+		timestamp = timestamp + INST_LATENCY - inst_timing_offset
 			
-			if sound then
-				ent:EmitSound( sound, 80 )
-
-				local eff = EffectData()
-				eff:SetOrigin( ent:GetPos() + Vector(0, 0, 60) )
-				eff:SetEntity( ent )
-
-				util.Effect( "musicnotes", eff, true, true )
-			end
-			
-		end*/
+		if sound then
+			// Add note to table of notes to be Played
+			// We do this instead of timer.Simple because the think hook is much more precise
+			table.insert( ent.QueuedNotes, { sound=sound, pos=pos, timestamp=timestamp } )
+		end
 
 	end
 

--- a/lua/entities/gmt_instrument_base/init.lua
+++ b/lua/entities/gmt_instrument_base/init.lua
@@ -22,18 +22,6 @@ function ENT:Initialize()
 	
 end
 
-function ENT:Think()
-
-	if !IsValid( self.Owner ) then return end
-
-	local dist = self:GetPos():Distance( self.Owner:GetPos() )
-
-	if dist > 128 then
-		self:RemoveInstOwner()
-	end
-
-end
-
 function ENT:InitializeAfter()
 end
 
@@ -41,51 +29,37 @@ local function HandleRollercoasterAnimation( vehicle, player )
 	return player:SelectWeightedSequence( ACT_GMOD_SIT_ROLLERCOASTER )
 end
 
-function ENT:TranslateOffset( vec )
-	return ( self:GetForward() * vec.x ) + ( self:GetRight() * -vec.y ) + ( self:GetUp() * vec.z )
-end
-
 function ENT:SetupChair( vecmdl, angmdl, vecvehicle, angvehicle )
 
-	local ang = self:GetAngles()
-	ang:RotateAroundAxis( ang:Forward(), 90 )
-
 	// Chair Model
-	if vecmdl then
-		vecmdl = self:TranslateOffset( vecmdl )
+	self.ChairMDL = ents.Create( "prop_physics_multiplayer" )
+	self.ChairMDL:SetModel( self.ChairModel )
+	self.ChairMDL:SetParent( self )
+	self.ChairMDL:SetPos( self:GetPos() + vecmdl )
+	self.ChairMDL:SetAngles( angmdl )
+	self.ChairMDL:DrawShadow( false )
 
-		self.ChairMDL = ents.Create( "prop_physics_multiplayer" )
-		self.ChairMDL:SetModel( self.ChairModel )
-		self.ChairMDL:SetParent( self )
-		self.ChairMDL:SetPos( self:GetPos() + vecmdl )
-		self.ChairMDL:SetAngles( self:GetAngles() + vecvehicle )
-
-		self.ChairMDL:DrawShadow( false )
-
-		self.ChairMDL:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
-		
-		self.ChairMDL:Spawn()
-		self.ChairMDL:Activate()
-		self.ChairMDL:SetOwner( self )
-		
-		local phys = self.ChairMDL:GetPhysicsObject()
-		if IsValid(phys) then
-			phys:EnableMotion(false)
-			phys:Sleep()
-		end
-		
-		self.ChairMDL:SetKeyValue( "minhealthdmg", "999999" )
+	self.ChairMDL:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
+	
+	self.ChairMDL:Spawn()
+	self.ChairMDL:Activate()
+	self.ChairMDL:SetOwner( self )
+	
+	local phys = self.ChairMDL:GetPhysicsObject()
+	if IsValid(phys) then
+		phys:EnableMotion(false)
+		phys:Sleep()
 	end
 	
+	self.ChairMDL:SetKeyValue( "minhealthdmg", "999999" )
+	
 	// Chair Vehicle
-	vecvehicle = self:TranslateOffset( vecvehicle )
-
 	self.Chair = ents.Create( "prop_vehicle_prisoner_pod" )
 	self.Chair:SetModel( "models/nova/airboat_seat.mdl" )
 	self.Chair:SetKeyValue( "vehiclescript","scripts/vehicles/prisoner_pod.txt" )
-	self.Chair:SetPos( self:GetPos() + vecvehicle )
-	self.Chair:SetParent( self )
-	self.Chair:SetAngles( self:GetAngles() + angvehicle )
+	self.Chair:SetPos( self.ChairMDL:GetPos() + vecvehicle )
+	self.Chair:SetParent( self.ChairMDL )
+	self.Chair:SetAngles( angvehicle )
 	self.Chair:SetNotSolid( true )
 	self.Chair:SetNoDraw( true )
 	self.Chair:DrawShadow( false )
@@ -112,7 +86,7 @@ local function HookChair( ply, ent )
 	if IsValid( inst ) && inst.Base == "gmt_instrument_base" then
 
 		if !IsValid( inst.Owner ) then
-			inst:AddInstOwner( ply )
+			inst:AddOwner( ply )
 			return true
 		else
 			if inst.Owner == ply then
@@ -124,6 +98,8 @@ local function HookChair( ply, ent )
 
 	end
 
+	return true
+
 end
 
 // Quick fix for overriding the instrument chair seating
@@ -134,33 +110,37 @@ function ENT:Use( ply )
 
 	if IsValid( self.Owner ) then return end
 
-	self:AddInstOwner( ply )
+	self:AddOwner( ply )
 
 end
 
-function ENT:AddInstOwner( ply )
+function ENT:AddOwner( ply )
 
 	if IsValid( self.Owner ) then return end
-
-	self.Owner = ply
 
 	net.Start( "InstrumentNetwork" )
 		net.WriteEntity( self )
 		net.WriteInt( INSTNET_USE, 4 )
 	net.Send( ply )
 
-	if IsValid( self.Chair ) then
-		ply.EntryPoint = ply:GetPos()
-		ply.EntryAngles = ply:EyeAngles()
+	ply.EntryPoint = ply:GetPos()
+	ply.EntryAngles = ply:EyeAngles()
 
-		ply:EnterVehicle( self.Chair )
+	self.Owner = ply
 
-		self.Owner:SetEyeAngles( Angle( 25, 90, 0 ) )
-	end
+	ply:EnterVehicle( self.Chair )
+
+	self.Owner:SetEyeAngles( Angle( 25, 90, 0 ) )
 
 end
 
-function ENT:RemoveInstOwner()
+function ENT:Think()
+	if self.Owner and IsValid( self.Owner ) and (not self.Owner:Alive()) then
+		self:RemoveOwner()
+	end
+end
+
+function ENT:RemoveOwner()
 
 	if !IsValid( self.Owner ) then return end
 
@@ -168,50 +148,36 @@ function ENT:RemoveInstOwner()
 		net.WriteEntity( nil )
 		net.WriteInt( INSTNET_USE, 3 )
 	net.Send( self.Owner )
+		
+	self.Owner:ExitVehicle( self.Chair )
 
-	if IsValid( self.Chair ) then
-		self.Owner:ExitVehicle( self.Chair )
-
-		self.Owner:SetPos( self.Owner.EntryPoint )
-		self.Owner:SetEyeAngles( self.Owner.EntryAngles )
-	end
+	self.Owner:SetPos( self.Owner.EntryPoint )
+	self.Owner:SetEyeAngles( self.Owner.EntryAngles )
 
 	self.Owner = nil
 
 end
 
-/*function ENT:NetworkKeys( keys )
+function ENT:NetworkKey( key, timestamp )
 
 	if !IsValid( self.Owner ) then return end // no reason to broadcast it
 
-	net.Start( "InstrumentNetwork" )
-
-		net.WriteEntity( self )
-		net.WriteInt( INSTNET_HEAR, 3 )
-		net.WriteTable( keys )
-
-	net.Broadcast()
-
-end*/
-
-function ENT:NetworkKey( key )
-
-	if !IsValid( self.Owner ) then return end // no reason to broadcast it
+	// Calculate note effect position
+	local pos = string.sub( key, 2, 3 )
+	pos = math.Fit( tonumber( pos ), 1, 36, -3.8, 4 )
+	pos = self.Owner:GetPos() + Vector( -15, pos * 10, -5 ) 
 
 	net.Start( "InstrumentNetwork" )
 
 		net.WriteEntity( self )
 		net.WriteInt( INSTNET_HEAR, 3 )
 		net.WriteString( key )
+		net.WriteFloat( timestamp )
+		net.WriteVector( pos )
 
 	net.Broadcast()
 
 end
-
-// Returns the approximate "fitted" number based on linear regression.
-function math.Fit( val, valMin, valMax, outMin, outMax )
-	return ( val - valMin ) * ( outMax - outMin ) / ( valMax - valMin ) + outMin
-end	
 
 net.Receive( "InstrumentNetwork", function( length, client )
 
@@ -226,7 +192,7 @@ net.Receive( "InstrumentNetwork", function( length, client )
 		// Filter out non-instruments
 		if ent.Base != "gmt_instrument_base" then return end
 
-		// This instrument doesn't have an owner...
+		// This instrument does not have an owner...
 		if !IsValid( ent.Owner ) then return end
 
 		// Check if the player is actually the owner of the instrument
@@ -234,24 +200,17 @@ net.Receive( "InstrumentNetwork", function( length, client )
 
 			// Gather note
 			local key = net.ReadString()
+
+			// Calculate timing
+			local timestamp = net.ReadFloat()
+			if not client.inst_timing_offset then
+				client.inst_timing_offset = os.clock() - timestamp
+			end
+
+			timestamp = timestamp + client.inst_timing_offset
 		
 			// Send it!!
-			ent:NetworkKey( key )
-
-			// Offset the note effect
-			local pos = string.sub( key, 2, 3 )
-			pos = math.Fit( tonumber( pos ), 1, 36, -3.8, 4 )
-
-			// Note effect
-			local eff = EffectData()
-				eff:SetOrigin( client:GetPos() + client:GetForward() + Vector( -15, pos * 10, -5 ) )
-			util.Effect( "musicnotes", eff, true, true )
-
-			// Gather notes
-			/*local keys = net.ReadTable()
-		
-			// Send them!!
-			ent:NetworkKeys( keys )*/
+			ent:NetworkKey( key, timestamp )
 
 		end
 
@@ -270,12 +229,12 @@ concommand.Add( "instrument_leave", function( ply, cmd, args )
 	// Filter out non-instruments
 	if !IsValid( ent ) || ent.Base != "gmt_instrument_base" then return end
 
-	// This instrument doesn't have an owner...
+	// This instrument does not have an owner...
 	if !IsValid( ent.Owner ) then return end
 
 	// Leave instrument
 	if ply == ent.Owner then
-		ent:RemoveInstOwner()
+		ent:RemoveOwner()
 	end
 
 end )

--- a/lua/entities/gmt_instrument_base/shared.lua
+++ b/lua/entities/gmt_instrument_base/shared.lua
@@ -13,6 +13,8 @@ INSTNET_USE		= 1
 INSTNET_HEAR	= 2
 INSTNET_PLAY	= 3
 
+INST_LATENCY    = 0.35
+
 //ENT.Keys = {}
 ENT.ControlKeys = { 
 	[KEY_TAB] =	function( inst, bPressed )
@@ -82,3 +84,8 @@ hook.Add( "PhysgunPickup", "NoPickupInsturmentChair", function( ply, ent )
 	end
 
 end )
+
+// Returns the approximate "fitted" number based on linear regression.
+function math.Fit( val, valMin, valMax, outMin, outMax )
+	return ( val - valMin ) * ( outMax - outMin ) / ( valMax - valMin ) + outMin
+end	

--- a/lua/entities/gmt_instrument_piano/init.lua
+++ b/lua/entities/gmt_instrument_piano/init.lua
@@ -4,10 +4,10 @@ include( "shared.lua" )
 
 function ENT:InitializeAfter()
 
-    self:SetupChair( 
-        nil, nil, //Vector( 75, 0, 0 ), Angle( 0, 0, 0 ), // chair model
-        Vector( 28, -25, 20 ), Angle( 0, 90, 0 ) // actual chair
-    )
+	self:SetupChair( 
+		Vector( 75, 0, 0 ), Angle( 0, 0, 0 ), // chair model
+		Vector( 0, 10, 24 ), Angle( 0, 90, 0 ) // actual chair
+	)
 
 end
 

--- a/lua/entities/gmt_instrument_piano/shared.lua
+++ b/lua/entities/gmt_instrument_piano/shared.lua
@@ -8,7 +8,7 @@ ENT.Category		= "Fun + Games"
 ENT.Spawnable		= true
 ENT.AdminSpawnable 	= true
 
-ENT.Model		= Model( "models/sims/piano.mdl" )
+ENT.Model		= Model( "models/fishy/furniture/piano.mdl" )
 ENT.SoundDir	= "GModTower/lobby/instruments/piano/"
 
 local darker = Color( 100, 100, 100, 150 )


### PR DESCRIPTION
This fixes the effect of network variations which makes notes be heard
out of the rhythm played. It's especially noticable on laggy or low tickrate servers, where no matter how skilled the player is the notes other people hear will be a mess.

>I used the workshop version to make this which is different than this github version, which is why some changes may seem nonsensical

